### PR TITLE
Add caminho instalacao

### DIFF
--- a/aseprite-installer.sh
+++ b/aseprite-installer.sh
@@ -33,7 +33,7 @@ eval set -- "$ARGS"
 while :
 do
   case "$1" in
-    --dir-instalacao) 
+    -f | --dir-instalacao) 
       if [ -d "$2" ]; then
         DIR_INSTALACAO="$2"
       else

--- a/aseprite-installer.sh
+++ b/aseprite-installer.sh
@@ -26,6 +26,24 @@ echo -e "\e[1;33m
 ----------------------------------------------------
 "
 
+# Processar argumentos para conseguir o diretorio padrao
+DIR_INSTALACAO=$HOME
+ARGS=$(getopt -a -n aseprite-installer.sh -o f: --long dir-instalacao: -- "$@")
+eval set -- "$ARGS"
+while :
+do
+  case "$1" in
+    --dir-instalacao) 
+      if [ -d "$2" ]; then
+        DIR_INSTALACAO="$2"
+      else
+        echo "$2 não é um diretório válido. Instalando no diretório padrão $DIR_INSTALACAO"
+      fi
+      shift 2 ;;
+    --) shift; break ;;
+  esac
+done
+
 # Checar a arquitetura e sistema operacional na qual estamos rodando
 OS_ARCH="$(uname -m)"
 command -v apt-get > /dev/null && OS_DISTRO="debian"
@@ -43,10 +61,10 @@ cd ~/Downloads
 [ $OS_ARCH = "x86" ] && { SKIA_ZIP="Skia-Linux-Release-x86.zip"; SKIA_RELEASE="Release-x86"; } 
 [ $OS_ARCH = "x86_64" ] && { SKIA_ZIP="Skia-Linux-Release-x64.zip";  SKIA_RELEASE="Release-x64"; }
 wget https://github.com/aseprite/skia/releases/download/m81-b607b32047/$SKIA_ZIP; mkdir -p ~/deps/skia; sudo unzip $SKIA_ZIP -d ~/deps/skia
-wget https://github.com/aseprite/aseprite/releases/download/v1.2.27/Aseprite-v1.2.27-Source.zip; mkdir -p ~/aseprite/build; sudo unzip Aseprite-v1.2.27-Source.zip -d ~/aseprite;
+wget https://github.com/aseprite/aseprite/releases/download/v1.2.27/Aseprite-v1.2.27-Source.zip; mkdir -p $DIR_INSTALACAO/aseprite/build; sudo unzip Aseprite-v1.2.27-Source.zip -d $DIR_INSTALACAO/aseprite;
 
 # Compilar o aseprite
-cd ~/aseprite/build
+cd $DIR_INSTALACAO/aseprite/build
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DLAF_BACKEND=skia \
@@ -70,7 +88,7 @@ rm $SKIA_ZIP
 DIR_SHARE=$HOME/.local/share
 DIR_ICONES=$DIR_SHARE/icons/hicolor
 ASEPRITE_DESKTOP=$DIR_SHARE/applications/aseprite.desktop
-cd $HOME/aseprite/build/bin/data/icons
+cd $DIR_INSTALACAO/aseprite/build/bin/data/icons
 mkdir -p $DIR_ICONES/16x16/apps && cp ase16.png $_/aseprite.png 
 mkdir -p $DIR_ICONES/32x32/apps && cp ase32.png $_/aseprite.png
 mkdir -p $DIR_ICONES/48x48/apps && cp ase48.png $_/aseprite.png

--- a/aseprite-installer.sh
+++ b/aseprite-installer.sh
@@ -40,8 +40,12 @@ do
       fi
       mkdir -p $2
       DIR_INSTALACAO=$2
-      shift 2 ;;
-    --) shift; break ;;
+      shift 2
+      ;;
+    --) 
+      shift
+      break
+      ;;
   esac
 done
 

--- a/aseprite-installer.sh
+++ b/aseprite-installer.sh
@@ -98,7 +98,7 @@ mkdir -p $DIR_ICONES/256x256/apps && cp ase256.png $_/aseprite.png
 echo "[Desktop Entry]" > $ASEPRITE_DESKTOP
 echo "Type=Application" >> $ASEPRITE_DESKTOP
 echo "Name=Aseprite" >> $ASEPRITE_DESKTOP
-echo "Exec=sh -c \"$HOME/aseprite/build/bin/aseprite\" " >> $ASEPRITE_DESKTOP
+echo "Exec=sh -c \"$DIR_INSTALACAO/aseprite/build/bin/aseprite\" " >> $ASEPRITE_DESKTOP
 echo "Icon=aseprite" >> $ASEPRITE_DESKTOP
 echo "Terminal=false" >> $ASEPRITE_DESKTOP
 echo "Categories=Graphics;2DGraphics;" >> $ASEPRITE_DESKTOP

--- a/aseprite-installer.sh
+++ b/aseprite-installer.sh
@@ -33,12 +33,13 @@ eval set -- "$ARGS"
 while :
 do
   case "$1" in
-    -f | --dir-instalacao) 
-      if [ -d "$2" ]; then
-        DIR_INSTALACAO="$2"
-      else
-        echo "$2 não é um diretório válido. Instalando no diretório padrão $DIR_INSTALACAO"
+    -f | --dir-instalacao)
+      if [ -f $2 ]; then
+        echo "$2 é um arquivo. Abortando."
+        exit 1
       fi
+      mkdir -p $2
+      DIR_INSTALACAO=$2
       shift 2 ;;
     --) shift; break ;;
   esac

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -45,19 +45,24 @@ then
   exit 1
 fi
 
-read -p "Você têm certeza que deseja desinstalar o aseprite e deletar TODO o conteúdo localizado no diretório $DIR_INSTALACAO? (Y/N): " -n 1 -r
+read -p "Você têm certeza que deseja desinstalar o aseprite e deletar TODO o conteúdo localizado no diretório $DIR_INSTALACAO? (Y/N): " RESPOSTA
 echo
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-  sudo rm -r $DIR_INSTALACAO/aseprite
-  sudo rm -r ~/deps
-  sudo rm $HOME/.local/share/applications/aseprite.desktop
-  sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png
-  sudo rm $HOME/.local/share/icons/hicolor/32x32/apps/aseprite.png
-  sudo rm $HOME/.local/share/icons/hicolor/48x48/apps/aseprite.png
-  sudo rm $HOME/.local/share/icons/hicolor/64x64/apps/aseprite.png
-  sudo rm $HOME/.local/share/icons/hicolor/128x128/apps/aseprite.png
-  sudo rm $HOME/.local/share/icons/hicolor/256x256/apps/aseprite.png
-else
-  echo "Abortando..."
-fi
+case "$RESPOSTA" in
+  [yY] | [yY][eE][sS] | [sS][iI][mM])
+    sudo rm -r $DIR_INSTALACAO/aseprite
+    sudo rm -r ~/deps
+    sudo rm $HOME/.local/share/applications/aseprite.desktop
+    sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png
+    sudo rm $HOME/.local/share/icons/hicolor/32x32/apps/aseprite.png
+    sudo rm $HOME/.local/share/icons/hicolor/48x48/apps/aseprite.png
+    sudo rm $HOME/.local/share/icons/hicolor/64x64/apps/aseprite.png
+    sudo rm $HOME/.local/share/icons/hicolor/128x128/apps/aseprite.png
+    sudo rm $HOME/.local/share/icons/hicolor/256x256/apps/aseprite.png
+    ;;
+  [nN] | [nN][oO] | [nN][aAãÃ][oO])
+    echo "Cancelando processo de desinstalação. Nenhum arquivo foi modificado."
+    ;;
+  *)
+    echo "Entrada inválida"
+    ;;
+esac

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -49,7 +49,7 @@ read -p "Você têm certeza que deseja desinstalar o aseprite localizado no dire
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  sudo rm -r ~/aseprite
+  sudo rm -r $DIR_INSTALACAO/aseprite
   sudo rm -r ~/deps
   sudo rm $HOME/.local/share/applications/aseprite.desktop
   sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -34,8 +34,12 @@ do
   case "$1" in
     -f | --dir-instalacao) 
         DIR_INSTALACAO="$2"
-        shift 2 ;;
-    --) shift; break ;;
+        shift 2
+        ;;
+    --)
+      shift
+      break
+      ;;
   esac
 done
 

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -26,12 +26,38 @@ echo -e "\e[1;33m
 ----------------------------------------------------
 "
 
-sudo rm -r ~/aseprite
-sudo rm -r ~/deps
-sudo rm $HOME/.local/share/applications/aseprite.desktop
-sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png
-sudo rm $HOME/.local/share/icons/hicolor/32x32/apps/aseprite.png
-sudo rm $HOME/.local/share/icons/hicolor/48x48/apps/aseprite.png
-sudo rm $HOME/.local/share/icons/hicolor/64x64/apps/aseprite.png
-sudo rm $HOME/.local/share/icons/hicolor/128x128/apps/aseprite.png
-sudo rm $HOME/.local/share/icons/hicolor/256x256/apps/aseprite.png
+DIR_INSTALACAO=$HOME/aseprite
+ARGS=$(getopt -a -n aseprite-installer.sh -o f: --long dir-instalacao: -- "$@")
+eval set -- "$ARGS"
+while :
+do
+  case "$1" in
+    --dir-instalacao) 
+        DIR_INSTALACAO="$2"
+        shift 2 ;;
+    --) shift; break ;;
+  esac
+done
+
+if ! [ -d $DIR_INSTALACAO ]
+then
+  echo "$DIR_INSTALACAO não existe. Abortando..."
+  exit 1
+fi
+
+read -p "Você têm certeza que deseja desinstalar o aseprite localizado no diretório $DIR_INSTALACAO? (Y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  sudo rm -r ~/aseprite
+  sudo rm -r ~/deps
+  sudo rm $HOME/.local/share/applications/aseprite.desktop
+  sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png
+  sudo rm $HOME/.local/share/icons/hicolor/32x32/apps/aseprite.png
+  sudo rm $HOME/.local/share/icons/hicolor/48x48/apps/aseprite.png
+  sudo rm $HOME/.local/share/icons/hicolor/64x64/apps/aseprite.png
+  sudo rm $HOME/.local/share/icons/hicolor/128x128/apps/aseprite.png
+  sudo rm $HOME/.local/share/icons/hicolor/256x256/apps/aseprite.png
+else
+  echo "Abortando..."
+fi

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Impedir que o usuário rode o script sendo root
 if [ $(id -u) = 0 ];
@@ -45,7 +45,7 @@ then
   exit 1
 fi
 
-read -p "Você têm certeza que deseja desinstalar o aseprite localizado no diretório $DIR_INSTALACAO? (Y/N): " -n 1 -r
+read -p "Você têm certeza que deseja desinstalar o aseprite e deletar TODO o conteúdo localizado no diretório $DIR_INSTALACAO? (Y/N): " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then

--- a/aseprite-uninstaller.sh
+++ b/aseprite-uninstaller.sh
@@ -32,7 +32,7 @@ eval set -- "$ARGS"
 while :
 do
   case "$1" in
-    --dir-instalacao) 
+    -f | --dir-instalacao) 
         DIR_INSTALACAO="$2"
         shift 2 ;;
     --) shift; break ;;
@@ -49,7 +49,7 @@ read -p "Você têm certeza que deseja desinstalar o aseprite e deletar TODO o c
 echo
 case "$RESPOSTA" in
   [yY] | [yY][eE][sS] | [sS][iI][mM])
-    sudo rm -r $DIR_INSTALACAO/aseprite
+    sudo rm -r $DIR_INSTALACAO
     sudo rm -r ~/deps
     sudo rm $HOME/.local/share/applications/aseprite.desktop
     sudo rm $HOME/.local/share/icons/hicolor/16x16/apps/aseprite.png


### PR DESCRIPTION
Permite que você modifique o caminho da instalação do Aseprite. Para isso, basta executar o instalador usando o -f ou --dir-instalacao. Exemplo:
`./aseprite-installer.sh -f /media/hd-externo/aseprite`
Para desinstalar que está em outro local, basta executar o desinstalador com -f ou --dir-instalacao. Exemplo:
`./aseprite-uninstaller.sh -f /media/hd-externo/aseprite`
Isso irá apagar todo o conteúdo de /media/hd-externo/aseprite, sem verificar se este caminho realmente é uma instalação aseprite (deve ser possível implementar algo que faça essa verificação).